### PR TITLE
Fix incorrect description in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Message flow in normal operation:
 1. The producer publishes messages to the SNS topic in the primary Region
 2. The primary SNS topic fans out messages to:
     - The active SQS queue in the primary Region
-    - The DR SQS queue in the primary Region
+    - The DR SQS queue in the secondary Region
 3. AWS Lambda functions process messages from both queues
 
 During failover:
 1. The producer switches to publishing messages to the SNS topic in the secondary Region
 2. The secondary SNS topic fans out messages to:
     - The active SQS queue in the secondary Region
-    - The DR SQS queue in the secondary Region
+    - The DR SQS queue in the primary Region
 3. AWS Lambda functions in the secondary Region take over message processing
 
 ## Prerequisites


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
In the How it Works section, the SNS topic fan out description lists the incorrect regions. E.g. In normal operation, the SNS topic fans out to the active queue in the **primary** region, and the DR queue in the **secondary** region. However the documentation lists both the **primary** region for this, which does not match the design.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
